### PR TITLE
add notifications when an action item is added to a channel

### DIFF
--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,0 +1,19 @@
+import {Reader} from "fp-ts/lib/Reader";
+import {AppDependencies} from "./app";
+
+export type NotificationSettings = {
+    on_action_add: boolean
+    on_action_complete: boolean
+    on_action_cancel: boolean
+}
+
+export function fetchNotificationSettings(workspaceId: string, channelId: string): Reader<AppDependencies, Promise<NotificationSettings>> {
+    return new Reader<AppDependencies, Promise<NotificationSettings>>(async () => {
+            return {
+                on_action_add: true,
+                on_action_complete: true,
+                on_action_cancel: false,
+            };
+        }
+    );
+}


### PR DESCRIPTION
Right now, the typical user behavior is to add one or more action items, then post the whole list again. By adding notifications, users will no longer be forced into the pattern.

In the future, we can add the ability to adjust the notification settings for a channel.